### PR TITLE
Fixes for memory bugs

### DIFF
--- a/src/allocation.f90
+++ b/src/allocation.f90
@@ -53,7 +53,7 @@ contains
       allocate ( theta_a  (nvec,1:ke_snow) ) ; theta_a   = 0.0_wp
       allocate ( dzm_sn   (nvec,1:ke_snow) ) ; dzm_sn    = 0.0_wp
 
-      allocate ( t_sn_n   (nvec,1:ke_snow) ) ; t_sn_n    = 0.0_wp
+      allocate ( t_sn_n   (nvec,1:ke_snow+1) ) ; t_sn_n    = 0.0_wp
 
       allocate ( top_sn   (nvec) )           ; top_sn = 0
 

--- a/src/input.f90
+++ b/src/input.f90
@@ -38,7 +38,7 @@ contains
       ! -------------------
 
       open(unit=20, status = "old", file=file)
-      nrows = 1
+      nrows = 0
       do
          read(20, *, iostat=iostatus)
          if(iostatus/=0) then ! to avoid end of file error.

--- a/src/mo_nix_stratigraphy.f90
+++ b/src/mo_nix_stratigraphy.f90
@@ -87,7 +87,7 @@ CONTAINS
          theta_a       , &   ! air ice content                            (-)
          t_sn                ! snow temperature (main level)              (K)
 
-      REAL    (KIND = wp), DIMENSION(nvec,1:ke_snow),  INTENT(INOUT) :: &
+      REAL    (KIND = wp), DIMENSION(nvec,1:ke_snow+1),  INTENT(INOUT) :: &
          t_sn_n
 
       REAL    (KIND = wp), DIMENSION(nvec),  INTENT(INOUT) :: &


### PR DESCRIPTION
Running valgrind on NIX revealed two memory issues:
1) nrows count was off by one, leading to an invalid read
2) t_sn_n was not allocated to the right size, leading to invalid reads/writes.