### PR TITLE
Nodal temperature and merge fixes

### DIFF
--- a/src/mo_nix_settling.f90
+++ b/src/mo_nix_settling.f90
@@ -137,10 +137,10 @@ CONTAINS
 
                   t_sn_n(i,ksn) = 2.0_wp * t_sn(i,ksn-1) - t_sn_n(i,ksn-1) ! adjusting nodal temperature for the upper node of the merged cell
 
-                  ! ... and reset roperties - FIXME: Doing this here means we have to give additional fields we don't need here to the
-                  !                                  subroutine. Doing this reset in update_nix_state() might make mor sense but would
-                  !                                  require some adaptations like a new field a marker that identifies
-                  !                                  melted/aggregated layers.
+                  ! ... and reset properties - FIXME: Doing this here means we have to give additional fields we don't need here to the
+                  !                                   subroutine. Doing this reset in update_nix_state() might make more sense but would
+                  !                                   require some adaptations like a new field a marker that identifies
+                  !                                   melted/aggregated layers.
                   hm_sn(i,ksn)       = 0.0_wp
                   zm_sn(i,ksn)       = 0.0_wp
                   dzm_sn(i,ksn)      = 0.0_wp
@@ -151,7 +151,6 @@ CONTAINS
 
                   rho_sn(i,ksn)      = 0.0_wp
                   t_sn(i,ksn)        = 0.0_wp
-                  t_sn_n(i,ksn+1)    = 0.0_wp
                   mass_sn(i,ksn)     = 0.0_wp
 
                   hcap_sn(i,ksn)     = 0.0_wp
@@ -198,17 +197,17 @@ CONTAINS
                hm_sn(i,ksn)       = 0.0_wp
                zm_sn(i,ksn)       = 0.0_wp
                dzm_sn(i,ksn)      = 0.0_wp
+
                theta_i(i,ksn)     = 0.0_wp
                theta_w(i,ksn)     = 0.0_wp
                theta_a(i,ksn)     = 0.0_wp
                theta_i_old(i,ksn) = 0.0_wp
+
                rho_sn(i,ksn)      = 0.0_wp
-
                t_sn(i,ksn)        = 0.0_wp
-
                t_sn_n(i,ksn+1)    = 0.0_wp
-
                mass_sn(i,ksn)     = 0.0_wp
+
                hcap_sn(i,ksn)     = 0.0_wp
                hcon_sn(i,ksn)     = 0.0_wp
                hdif_sn(i,ksn)     = 0.0_wp

--- a/src/mo_nix_snow_util.f90
+++ b/src/mo_nix_snow_util.f90
@@ -236,7 +236,7 @@ CONTAINS
          ivstart , &
          ivend
 
-      INTEGER, DIMENSION(nvec), INTENT(IN) :: &
+      INTEGER, DIMENSION(nvec), INTENT(INOUT) :: &
          top                 ! index of the first (top) layer index       (-)
 
       INTEGER, INTENT(IN)  ::  &
@@ -273,6 +273,22 @@ CONTAINS
 
 
       DO i = ivstart, ivend
+
+         ! -----------------------------------
+         ! Remove snow layers with zero height
+         ! -----------------------------------
+
+         IF(top(i) .GE. 1) THEN
+
+            DO ksn=1,top(i)
+
+               IF(dzm_sn(i,ksn) .EQ. 0) THEN
+                  top(i) = top(i) - 1
+               ENDIF
+
+            ENDDO ! ksn
+
+         ENDIF
 
          IF(top(i) .GE. 1) THEN
 

--- a/src/mo_nix_stratigraphy.f90
+++ b/src/mo_nix_stratigraphy.f90
@@ -134,8 +134,12 @@ CONTAINS
                theta_i(i,top(i)) = rho_hn(i) / rho_i
                theta_w(i,top(i)) = 0.0_wp
                theta_a(i,top(i)) = 1.0_wp - theta_i(i,top(i)) - theta_w(i,top(i))
-               t_sn(i,top(i))    = min(t(i),t0_melt)
-               t_sn_n(i,top(i) + 1) = min( 2.0_wp*t_sn(i,top(i)) - t_sn_n(i,top(i)), t0_melt)
+               IF (top(i) .EQ. 1) THEN
+                  ! First snow element also needs to define the first nodal temperature
+                  t_sn_n(i,top(i))   = min(t(i),t0_melt)
+               ENDIF
+               t_sn_n(i,top(i) + 1) = t_sn(i,top(i))
+               t_sn(i,top(i))       = 0.5_wp * (t_sn_n(i,top(i)) + t_sn_n(i,top(i)+1))
 
                ! Reset new snow storage
                hn_sn(i) = 0.0_wp
@@ -219,9 +223,9 @@ CONTAINS
                theta_w(i,top(i))  = 0.0_wp           ! new snow is always dry
                theta_a(i,top(i))  = 1.0_wp - theta_i(i,top(i)) - theta_w(i,top(i))
 
-               t_sn(i,top(i))     = MIN(t(i), t0_melt)
+               t_sn_n(i,top(i) + 1) = t_sn(i,top(i))
+               t_sn(i,top(i))       = 0.5_wp * (t_sn_n(i,top(i)) + t_sn_n(i,top(i)+1))
 
-               t_sn_n(i,top(i) + 1) = min( 2.0_wp*t_sn(i,top(i)) - t_sn_n(i,top(i)), t0_melt)
                ! Reset new snow storage
                hn_sn(i) = 0.0_wp
 

--- a/src/mo_nix_stratigraphy.f90
+++ b/src/mo_nix_stratigraphy.f90
@@ -138,7 +138,7 @@ CONTAINS
                   ! First snow element also needs to define the first nodal temperature
                   t_sn_n(i,top(i))   = min(t(i),t0_melt)
                ENDIF
-               t_sn_n(i,top(i) + 1) = t_sn(i,top(i))
+               t_sn_n(i,top(i) + 1) = t_sn_n(i,top(i))
                t_sn(i,top(i))       = 0.5_wp * (t_sn_n(i,top(i)) + t_sn_n(i,top(i)+1))
 
                ! Reset new snow storage
@@ -223,7 +223,7 @@ CONTAINS
                theta_w(i,top(i))  = 0.0_wp           ! new snow is always dry
                theta_a(i,top(i))  = 1.0_wp - theta_i(i,top(i)) - theta_w(i,top(i))
 
-               t_sn_n(i,top(i) + 1) = t_sn(i,top(i))
+               t_sn_n(i,top(i) + 1) = t_sn_n(i,top(i))
                t_sn(i,top(i))       = 0.5_wp * (t_sn_n(i,top(i)) + t_sn_n(i,top(i)+1))
 
                ! Reset new snow storage


### PR DESCRIPTION
Fixing the following:

- Fixes to the initialization of nodal temperatures
    - When the first snow element is added, the bottom nodal temperature needs to be defined too, in addition to the upper nodal temperature. Otherwise, the bottom node is propagated with 0 Kelvin, which can wreak havoc when solving the heat equation
    - New elements are now initialized with the current surface temperature, instead of air temperature (similar to the procedure in SNOWPACK). Since the air temperature is generally equal or above the snow surface temperature, initializing the element temperature with the air temperature led to the surface temperature to be frequently initialized above the air temperature. This leads to spurious (and sometimes strong) heat fluxes directed toward the snow surface.

- Removing snow layers with zero depth (could occur at this point in the code with high sublimation rates)

- When removing layers, the nodal temperature should not be reset to 0 (0 Kelvin), since the node might be shared with layers above (in case the element to be removed is not the surface element)