### PR TITLE
Revised heat equation solver

### DIFF
--- a/src/mo_nix_constants.f90
+++ b/src/mo_nix_constants.f90
@@ -62,7 +62,9 @@ MODULE mo_nix_constants
 
       theta_s                     = 1.0_wp                 , & ! Saturated Water Content, for now we say 1.0
       theta_r                     = 0.0_wp                 , & ! Minimum amount of liquid water that will remain
-      ctalb                       = 0.004_wp                   ! VS : added snow physical constants
+      ctalb                       = 0.004_wp               , & ! VS : added snow physical constants
+
+      e_snow                      = 0.98_wp                    ! lw emissivity for snow
 
    REAL  (KIND=wp), PARAMETER :: eps_div  = 1.0E-6_wp
 

--- a/src/mo_nix_heat_equation.f90
+++ b/src/mo_nix_heat_equation.f90
@@ -355,7 +355,7 @@ contains
       do i = ivstart, ivend
          if(top(i) .gt. 1) then            ! snow on the ground
             U = t_sn_n(i,:)
-            ddU = 0.0_wp
+            dU = 0.0_wp
 
             iterloop: do iteration = 1,maxiter
 

--- a/src/mo_nix_meteo_util.f90
+++ b/src/mo_nix_meteo_util.f90
@@ -454,6 +454,7 @@ CONTAINS
          ! + Calculate absprbed short-wave radiation
          ! -------------------------
 
+         swflx_sn_abs(i,:) = 0.0_wp
          tbloop: DO ksn = top(i), 1, -1
 
             k_ext               = ( rho_sn(i,ksn) / 3.0_wp ) + 50.0_wp


### PR DESCRIPTION
Overhaul of the heat equation solver to closer match the SNOWPACK version:

- Setting up the matrix in closer agreement with the code logic used in SNOWPACK
- Solver now solves for temperature increments, instead of absolute temperatures, similar to SNOWPACK's solver
- Adding iteration loop to refine solution (similar to SNOWPACK)
- Implementation of explicit boundary conditions in case water is present in the snow
- Some renaming of variables (like the iteration temperatures, exchange coefficients) to match the naming in SNOWPACK
- Some code formatting and improved comments, including more comments that makes matching the SNOWPACK source code more transparent
- Snow emissivity is now a constant defined in mo_nix_constants.f90