### PR TITLE
Improved handling of precipitation

### DIFF
--- a/src/mo_nix_config.f90
+++ b/src/mo_nix_config.f90
@@ -44,9 +44,11 @@ MODULE mo_nix_config
 
    REAL (KIND = wp), PARAMETER ::   &
       zdt               = 900.0_wp              , & ! model timestep : note this should correspond to the meteotimestep     (s)
- 
-      min_height_layer  = 0.01_wp              , & ! minimum layer thickness
-      max_height_layer  = 0.05_wp                   ! maximum layer thickness
+
+      min_newsnow_layer = 0.002_wp              , & ! minimum new snow layer thickness, precip below this threshold is kept in
+                                                    ! storage, until sufficient precipitation has accumulated to build min_newsnow_layer (m)
+      min_height_layer  = 0.01_wp               , & ! minimum layer thickness (m)
+      max_height_layer  = 0.05_wp                   ! maximum layer thickness (m)
 
    REAL (KIND = wp) :: &
 


### PR DESCRIPTION
A new parameter `min_newsnow_layer` is introduced to determine when precipitation is added to the snowpack. This parameter can be set independently from the other layer spacing parameters controlling model layer spacing. If the surface layer is thin, and the layer to be added is thin, the top layer will grow. Only when the top layer is sufficiently thick, precipitation will be deposited in a new layer. This avoids that precipitation is added at different timesteps, depending on the layer spacing settings.